### PR TITLE
parse(): Check year-pos for Roman-numerals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ function parse(name, options = { strict: false, flagged: true, erase: [], defaul
     .split('.')
     .filter((word, position) => word === words[position])
     .map((word, i) => {
-      if (i === (yearPos - 1) && word.split('').every(char => ['i', 'I'].includes(char))) {
+      if ((i === (yearPos - 1) || i === (words.length - 1)) && word.split('').every(char => ['i', 'I'].includes(char))) {
         return word.length
       } else {
         return word

--- a/src/index.js
+++ b/src/index.js
@@ -205,14 +205,24 @@ function parse(name, options = { strict: false, flagged: true, erase: [], defaul
     release[property] = result.match || options.defaults[property]
   })
 
+  let yearPos = 0
+  words.reduceRight((_, w, i) => {
+    if (/19|20\d{2}/.test(w)) {
+      yearPos = i
+    }
+  }, null)
+
   release.title = waste
     .replace(/[\.\-]+/, '.')
     .split('.')
     .filter((word, position) => word === words[position])
-    .map(word => word.split('').every(char => ['i', 'I'].includes(char)) ? word.length : word)
-    .join(' ')
-    .toLowerCase()
-    .replace(/(^([a-zA-Z\p{M}]))|([ -][a-zA-Z\p{M}])/g, s => s.toUpperCase()) // ucwords
+    .map((word, i) => {
+      if (i === (yearPos - 1) && word.split('').every(char => ['i', 'I'].includes(char))) {
+        return word.length
+      } else {
+        return word
+      }
+    })
 
   release.generated = stringify(release, options)
 


### PR DESCRIPTION
Issue: #29 

This commit avoids titles with `i` in the middle of the title (directly translated as "*in*", for danish titles) being converted from roman numerals (capital *I, II, III*) to 1, 2, 3

Example
```
Nattevagten - Daemoner gaar i arv
```
Would wrongly be interpreted as roman numerals and replace with a number instead of a letter, which in this case means "in" directly translated.
```
Nattevagten - Daemoner gaar 1 arv
```

This commit assumes the roman numerals are directly before the year-tag. Personally I've never witnessed movies with roman numerals in the middle of the title.

If you think this needs to be broken up in several functions I agree, but since parse() is one big function I'll let you decide how to proceed with refactoring this.

Also.. If you want to assume that year is always present for scene-releases and not handle that case as in https://github.com/thcolin/oleoo/pull/30/commits/e11b90b812b366763414ac366f97a4e4f28a8384 feel free to edit or redact that commit.